### PR TITLE
remove interpolation of single-quoted strings

### DIFF
--- a/coffee_script.lang
+++ b/coffee_script.lang
@@ -81,9 +81,6 @@
                     <include>
                         <context ref="def:line-continue"/>
                         <context ref="def:escape"/>
-                        <context id="interpolation-heredocs-single" style-ref="assessor" extend-parent="false">
-                            <match>\#{[^}]+}</match>
-                        </context>
                     </include>
                 </context>
 
@@ -115,9 +112,6 @@
                     <include>
                         <context ref="def:line-continue"/>
                         <context ref="def:escape"/>
-                        <context id="interpolation-string-single" style-ref="assessor" extend-parent="false">
-                            <match>\#{[^}]+}</match>
-                        </context>
                     </include>
                 </context>
 

--- a/test.coffee
+++ b/test.coffee
@@ -13,7 +13,8 @@ square = (x) -> x * x
 matcher = /mymatch/g
 
 # Interpolation
-html = "And the number is #{number}"
+html0 = "And the number is #{number}"
+html1 = 'This is not an #{interpolation}'
 
 # Heredocs
 


### PR DESCRIPTION
String interpolation only works with double-quoted strings and heredocs, not single-quoted ones.
