### PR TITLE
Array comprehensions being mistaken for functions

### DIFF
--- a/coffee_script.lang
+++ b/coffee_script.lang
@@ -212,7 +212,7 @@
                 </context>
 
                 <context id="functions" style-ref="function">
-                    <keyword>\b[A-Za-z0-9_]+\b(?=\s*?(=|:)\s*?(\(|-\>|=\>))</keyword>
+                    <keyword>\b\w+\b(?=\s*(=|:)\s*(\([\w,\s]*\))?\s*(-\>|=\>))</keyword>
                 </context>
 
                 <context id="constructors" style-ref="constructors">


### PR DESCRIPTION
For example:

![example](http://gyazo.com/3ac5b7c030a489adcf7a6afd2f0d27ff.png)

Here's the regex: `\b[A-Za-z0-9_]+\b(?=\s*?(=|:)\s*?(\(|-\>|=\>))`

I'm pretty sure it is checking if the expression has parentheses after an `=` or a `->`/`=>`, when it should be just checking if it has a `->`/`=>` after an `=` with or without parentheses preceding?
