### PR TITLE
Recognize destructuring assignment in function arguments

### DIFF
--- a/coffee_script.lang
+++ b/coffee_script.lang
@@ -225,7 +225,7 @@
                 </context>
 
                 <context id="functions" style-ref="function">
-                    <keyword>\b\w+\b(?=\s*(=|:)\s*(\([\w,\s]*\))?\s*(-\>|=\>))</keyword>
+                    <keyword>\b\w+\b(?=\s*(=|:)\s*(\([\w,\s@=\[\]\{\}.]*\))?\s*(-\>|=\>))</keyword>
                 </context>
 
                 <context id="constructors" style-ref="constructors">


### PR DESCRIPTION
Examples:

``` coffeescript
class Test
    constructor: (@name) ->

    rest: ([_, rst...]) -> rst
```

See http://jashkenas.github.com/coffee-script/#destructuring

It may make sense to make the pattern for the inside of the argument list simply [^)]\* instead of listing the characters explicitly.
