### PR TITLE
Add extensionless Cakefile to globs

### DIFF
--- a/coffee_script.lang
+++ b/coffee_script.lang
@@ -23,7 +23,7 @@
 <language id="coffee" _name="CoffeeScript" version="2.0" _section="Scripts">
     <metadata>
         <property name="mimetypes">application/coffeescript;text/coffeescript;application/cakefile;text/cakefile;</property>
-        <property name="globs">*.coffee;*.Cakefile</property>
+        <property name="globs">*.coffee;Cakefile;*.Cakefile</property>
         <property name="line-comment-start">#</property>
         <property name="block-comment-start">###</property>
         <property name="block-comment-end">###</property>


### PR DESCRIPTION
So that files called Cakefile are syntax-highlighted as well.
