### PR TITLE
Fix the version="3.0" confusion

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,8 +7,7 @@ This project adds [CoffeeScript] syntax highlighting to the gedit text editor. (
 1. Download and place coffee_script.lang in `~/.local/share/gtksourceview-2.0/language-specs`
 
     > Note: if those directories don't exist, make them and gedit will know what to do.
-    > **Important:** if you are using GTK3 (e.g. Gnome Shell) use `gtksourceview-3.0` folder instead of 2.0
-    > ( you may also need to change the `version="2.0"` attribute at the top of the file to `version="3.0" )`.
+    > **Important:** if you are using GTK3 (e.g. Gnome Shell) use `gtksourceview-3.0/language-specs` folder instead of 2.0.
 
 2. Run gedit and open a CoffeeScript file or Cakefile.
 
@@ -21,7 +20,7 @@ Patches and improvements welcome!
 1. Download and place rubycius-mod.xml in `~/.local/share/gtksourceview-2.0/styles`
 
     > Note: if those directories don't exist, make them and gedit will know what to do.
-    > **Important:** if you are using GTK3 (e.g. Gnome Shell) use `gtksourceview-3.0` folder instead of 2.0.
+    > **Important:** if you are using GTK3 (e.g. Gnome Shell) use `gtksourceview-3.0/styles` folder instead of 2.0.
 
 2. Run gedit then Edit > Preferences > Fonts and Colors > Color Scheme > Rubycius-Mod
 


### PR DESCRIPTION
Sorry about the confusion, there's indeed no need to change the "version" attribute.

Instead I got tripped by the instructions referring to the "gtksourceview-3.0 folder" (assuming it meant just "~/.local/share/gtksourceview-3.0") when on closer reading the instructions tell to put the file in ~/.local/share/gtksourceview-3.0/language-specs. This commit clarifies the meaning by adding the "language-spec" (and "styles") subfolder to the GTK3 instructions.

The earlier point about version="3.0" being needed was just me being confused.
