### PR TITLE
Merged literate_coffee_script.lang from gist, fixing #30 and #27

### DIFF
--- a/coffee_script.lang
+++ b/coffee_script.lang
@@ -23,7 +23,7 @@
 <language id="coffee" _name="CoffeeScript" version="2.0" _section="Scripts">
     <metadata>
         <property name="mimetypes">application/coffeescript;text/coffeescript;application/cakefile;text/cakefile;application/icedcoffeescript;text/icedcoffeescript</property>
-        <property name="globs">*.coffee;Cakefile;*.Cakefile;*.coffee.erb;*.iced;*.iced.erb;*.litcoffee</property>
+        <property name="globs">*.coffee;Cakefile;*.Cakefile;*.coffee.erb;*.iced;*.iced.erb</property>
         <property name="line-comment-start">#</property>
         <property name="block-comment-start">###</property>
         <property name="block-comment-end">###</property>

--- a/install.sh
+++ b/install.sh
@@ -2,3 +2,4 @@ mkdir -p ~/.local/share/gtksourceview-3.0
 mkdir -p ~/.local/share/gtksourceview-3.0/language-specs
 cp rubycius-mod.xml ~/.local/share/gtksourceview-3.0/language-specs
 cp coffee_script.lang ~/.local/share/gtksourceview-3.0/language-specs
+cp literate_coffee_script.lang ~/.local/share/gtksourceview-3.0/language-specs

--- a/literate_coffee_script.lang
+++ b/literate_coffee_script.lang
@@ -21,22 +21,22 @@
 
 -->
 <language id="litcoffee" _name="Literate CoffeeScript" version="2.0" _section="Scripts">
-	<metadata>
-		<property name="mimetypes">application/litcoffeescript;text/litcoffeescript</property>
-		<property name="globs">*.litcoffee</property>
-	</metadata>
-	<definitions>
-		<context id="coffee-block" class="no-spell-check" end-at-line-end="true">
-			<start><![CDATA[^ {4,}]]></start>
-			<include>
-				<context ref="coffee:coffee"/>
-			</include>
-		</context>
-		<replace id="markdown:code-block" ref="coffee-block"/>
-		<context id="litcoffee">
-			<include>
-				<context ref="markdown:markdown"/>
-			</include>
-		</context>
-	</definitions>
+    <metadata>
+        <property name="mimetypes">application/litcoffeescript;text/litcoffeescript</property>
+        <property name="globs">*.litcoffee;*.coffee.md</property>
+    </metadata>
+    <definitions>
+        <context id="coffee-block" class="no-spell-check" end-at-line-end="true">
+            <start><![CDATA[^ {4,}]]></start>
+            <include>
+                <context ref="coffee:coffee"/>
+            </include>
+        </context>
+        <replace id="markdown:code-block" ref="coffee-block"/>
+        <context id="litcoffee">
+            <include>
+                <context ref="markdown:markdown"/>
+            </include>
+        </context>
+    </definitions>
 </language>


### PR DESCRIPTION
As requested in #30 I've merged in `literate_coffee_script.lang` from [gist](https://gist.github.com/niclashoyer/4493699) by @niclashoyer.

With gists being git repositories on their own, I took the liberty of merging, such that @niclashoyer remains author in the history...
(gists are really awesome)

Back on topic, I'm not sure how well it recognizes `*.coffee.md` files, first time I opened a file with that name it was highlighted as markdown. However, when manually set it to "Literate CoffeeScript" it worked for all the other `*.coffee.md` files I opened afterwards.
